### PR TITLE
Fix action

### DIFF
--- a/.github/workflows/updatejson.yml
+++ b/.github/workflows/updatejson.yml
@@ -32,7 +32,7 @@ jobs:
               id: json
               run: |
                   npm run json
-                  changes="$(git diff)"
+                  changes="$(git diff --staged dist)"
                   if [ "$changes" ]
                   then
                   changes=1


### PR DESCRIPTION
Because `npm run json` does `git add`, there's nothing left in `changes`. They are in `staged changes` instead.